### PR TITLE
Fixes for Telstra Internet Optimiser

### DIFF
--- a/telstra_smart_modem/base.py
+++ b/telstra_smart_modem/base.py
@@ -54,7 +54,7 @@ class ModemBase:
 
     # Extract the CSRFtoken from the modem index page.
     def _getCSRFtoken(self):
-        response = self.session.get(self.base_url, timeout=HTTP_TIMEOUT)
+        response = self.session.get(f"{self.base_url}/home.lp", timeout=HTTP_TIMEOUT)
         self._extractCSRFtoken_html(response.text)
 
     # Authenticate with the Modem using SRP.

--- a/telstra_smart_modem/modem.py
+++ b/telstra_smart_modem/modem.py
@@ -33,7 +33,7 @@ class Modem(ModemBase):
     def getModemStatus(self):
 
         def getStatusModal():
-            response = self.session.get(self.base_url, timeout=HTTP_TIMEOUT)
+            response = self.session.get(f"{self.base_url}/home.lp", timeout=HTTP_TIMEOUT)
             soup = bs4.BeautifulSoup(response.text, 'html.parser')
             status = soup.find('img', attrs={"src": "img/status.png"})
             if status:


### PR DESCRIPTION
When Internet Optimiser is enabled, the modem's index (`http://192.168.0.1/`) goes to the DUMAOS UI instead of the normal Telstra/Technicolor one, so `/home.lp` is required to go to it instead.

This works with and without Internet Optimiser.